### PR TITLE
URL Navigation Fix

### DIFF
--- a/app/appointments/edit/route.js
+++ b/app/appointments/edit/route.js
@@ -1,4 +1,5 @@
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import Ember from 'ember';
 import moment from 'moment';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
@@ -6,12 +7,13 @@ import { translationMacro as t } from 'ember-i18n';
 
 const {
   get,
+  isEmpty,
   RSVP: {
     resolve
   }
 } = Ember;
 
-export default AbstractEditRoute.extend(PatientListRoute, {
+export default AbstractEditRoute.extend(AddToPatientRoute, PatientListRoute, {
   editTitle: t('appointments.editTitle'),
   modelName: 'appointment',
   newButtonText: t('appointments.buttons.newButton'),
@@ -26,7 +28,7 @@ export default AbstractEditRoute.extend(PatientListRoute, {
       selectPatient: true,
       startDate: new Date()
     };
-    if (!Ember.isEmpty(idParam) && params[idParam] === 'newsurgery') {
+    if (!isEmpty(idParam) && params[idParam] === 'newsurgery') {
       newData.appointmentType = 'Surgery';
       newData.allDay = false;
       newData.endDate = moment().add('1', 'hours').toDate();
@@ -53,10 +55,16 @@ export default AbstractEditRoute.extend(PatientListRoute, {
   model(params) {
     let idParam = this.get('idParam');
     let modelId = params[idParam];
-    if (!Ember.isEmpty(idParam) && (modelId.indexOf('new') === 0)) {
-      return this._createNewRecord(params);
+    if (!isEmpty(idParam) && (modelId.indexOf('new') === 0)) {
+      if (!isEmpty(params.forPatientId)) {
+        let modelPromise = this._super(params);
+        return this._setPatientOnModel(modelPromise, params.forPatientId);
+      } else {
+        return this._createNewRecord(params);
+      }
     } else {
       return this._super(params);
     }
   }
+
 });

--- a/app/appointments/edit/route.js
+++ b/app/appointments/edit/route.js
@@ -59,6 +59,9 @@ export default AbstractEditRoute.extend(AddToPatientRoute, PatientListRoute, {
       if (!isEmpty(params.forPatientId)) {
         let modelPromise = this._super(params);
         return this._setPatientOnModel(modelPromise, params.forPatientId);
+      } else if (!isEmpty(params.forVisitId)) {
+        let modelPromise = this._super(params);
+        return this._setVisitOnModel(modelPromise, params.forforVisitId);
       } else {
         return this._createNewRecord(params);
       }

--- a/app/appointments/edit/route.js
+++ b/app/appointments/edit/route.js
@@ -1,5 +1,5 @@
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
-import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
+import AddToPatient from 'hospitalrun/mixins/add-to-patient-route';
 import Ember from 'ember';
 import moment from 'moment';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
@@ -13,7 +13,7 @@ const {
   }
 } = Ember;
 
-export default AbstractEditRoute.extend(AddToPatientRoute, PatientListRoute, {
+export default AbstractEditRoute.extend(AddToPatient, PatientListRoute, {
   editTitle: t('appointments.editTitle'),
   modelName: 'appointment',
   newButtonText: t('appointments.buttons.newButton'),
@@ -61,7 +61,7 @@ export default AbstractEditRoute.extend(AddToPatientRoute, PatientListRoute, {
         return this._setPatientOnModel(modelPromise, params.forPatientId);
       } else if (!isEmpty(params.forVisitId)) {
         let modelPromise = this._super(params);
-        return this._setVisitOnModel(modelPromise, params.forforVisitId);
+        return this._setVisitOnModel(modelPromise, params.forVisitId);
       } else {
         return this._createNewRecord(params);
       }

--- a/app/imaging/edit/route.js
+++ b/app/imaging/edit/route.js
@@ -1,10 +1,11 @@
 import { translationMacro as t } from 'ember-i18n';
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import ChargeRoute from 'hospitalrun/mixins/charge-route';
 import Ember from 'ember';
 import moment from 'moment';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
-export default AbstractEditRoute.extend(ChargeRoute, PatientListRoute, {
+export default AbstractEditRoute.extend(AddToPatientRoute, ChargeRoute, PatientListRoute, {
   editTitle: t('imaging.titles.editTitle'),
   modelName: 'imaging',
   newTitle: t('imaging.titles.editTitle'),

--- a/app/labs/edit/route.js
+++ b/app/labs/edit/route.js
@@ -1,11 +1,12 @@
-import Ember from 'ember';
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import ChargeRoute from 'hospitalrun/mixins/charge-route';
+import Ember from 'ember';
 import moment from 'moment';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
 import { translationMacro as t } from 'ember-i18n';
 
-export default AbstractEditRoute.extend(ChargeRoute, PatientListRoute, {
+export default AbstractEditRoute.extend(AddToPatientRoute, ChargeRoute, PatientListRoute, {
   editTitle: t('labs.editTitle'),
   modelName: 'lab',
   newTitle: t('labs.newTitle'),

--- a/app/medication/edit/route.js
+++ b/app/medication/edit/route.js
@@ -1,12 +1,16 @@
 import { translationMacro as t } from 'ember-i18n';
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import Ember from 'ember';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations'; // inventory-locations mixin is needed for fulfill-request mixin!
 import moment from 'moment';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
 import uuid from 'npm:uuid';
-export default AbstractEditRoute.extend(FulfillRequest, InventoryLocations, PatientListRoute, {
+
+const { isEmpty } = Ember;
+
+export default AbstractEditRoute.extend(AddToPatientRoute, FulfillRequest, InventoryLocations, PatientListRoute, {
   editTitle: t('medication.titles.editMedicationRequest'),
   modelName: 'medication',
   newTitle: t('medication.titles.newMedicationRequest'),
@@ -27,8 +31,13 @@ export default AbstractEditRoute.extend(FulfillRequest, InventoryLocations, Pati
 
   model(params) {
     let idParam = this.get('idParam');
+    let modelPromise = this._super(params);
     if (!Ember.isEmpty(idParam) && params[idParam] === 'new' || params[idParam] === 'dispense') {
-      return this._createNewRecord(params);
+      if (!isEmpty(params.forPatientId)) {
+        return this._setPatientOnModel(modelPromise, params.forPatientId);
+      } else {
+        return this._createNewRecord(params);
+      }
     } else {
       return this._super(params);
     }

--- a/app/medication/edit/route.js
+++ b/app/medication/edit/route.js
@@ -35,6 +35,8 @@ export default AbstractEditRoute.extend(AddToPatientRoute, FulfillRequest, Inven
     if (!Ember.isEmpty(idParam) && params[idParam] === 'new' || params[idParam] === 'dispense') {
       if (!isEmpty(params.forPatientId)) {
         return this._setPatientOnModel(modelPromise, params.forPatientId);
+      } else if (!isEmpty(params.forVisitId)) {
+        return this._setVisitOnModel(modelPromise, params.forVisitId);
       } else {
         return this._createNewRecord(params);
       }

--- a/app/mixins/add-to-patient-route.js
+++ b/app/mixins/add-to-patient-route.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const { get, isEmpty, Mixin } = Ember;
+
+export default Mixin.create({
+  queryParams: {
+    forPatientId: {
+      refreshModel: false
+    }
+  },
+
+  model(params) {
+    let idParam = get(this, 'idParam');
+    let modelPromise = this._super(params);
+    if (!isEmpty(params.forPatientId) && params[idParam] === 'new') {
+      return this._setPatientOnModel(modelPromise, params.forPatientId);
+    } else {
+      return modelPromise;
+    }
+  },
+
+  /**
+   * Resolves the model promise and then sets the patient information on the model.
+   */
+  _setPatientOnModel(modelPromise, patientId) {
+    let store = get(this, 'store');
+    return modelPromise.then((model) => {
+      return store.find('patient', patientId).then((patient) => {
+        model.set('patient', patient);
+        model.set('returnToPatient', patientId);
+        model.set('selectPatient', false);
+        return model;
+      });
+    });
+  }
+});

--- a/app/mixins/add-to-patient-route.js
+++ b/app/mixins/add-to-patient-route.js
@@ -20,6 +20,8 @@ export default Mixin.create({
         return this._setPatientOnModel(modelPromise, params.forPatientId);
       } else if (!isEmpty(params.forVisitId)) {
         return this._setVisitOnModel(modelPromise, params.forVisitId);
+      } else {
+        return this._createNewRecord(params);
       }
     } else {
       return modelPromise;
@@ -51,6 +53,7 @@ export default Mixin.create({
         model.set('visit', visit);
         model.set('returnToVisit', visitId);
         model.set('selectPatient', false);
+        model.set('patient', visit.get('patient'));
         return model;
       });
     });

--- a/app/mixins/add-to-patient-route.js
+++ b/app/mixins/add-to-patient-route.js
@@ -6,14 +6,21 @@ export default Mixin.create({
   queryParams: {
     forPatientId: {
       refreshModel: false
+    },
+    forVisitId: {
+      refreshModel: false
     }
   },
 
   model(params) {
     let idParam = get(this, 'idParam');
     let modelPromise = this._super(params);
-    if (!isEmpty(params.forPatientId) && params[idParam] === 'new') {
-      return this._setPatientOnModel(modelPromise, params.forPatientId);
+    if (params[idParam] === 'new') {
+      if (!isEmpty(params.forPatientId)) {
+        return this._setPatientOnModel(modelPromise, params.forPatientId);
+      } else if (!isEmpty(params.forVisitId)) {
+        return this._setVisitOnModel(modelPromise, params.forVisitId);
+      }
     } else {
       return modelPromise;
     }
@@ -28,6 +35,21 @@ export default Mixin.create({
       return store.find('patient', patientId).then((patient) => {
         model.set('patient', patient);
         model.set('returnToPatient', patientId);
+        model.set('selectPatient', false);
+        return model;
+      });
+    });
+  },
+
+  /**
+   * Resolves the model promise and then sets the visit information on the model.
+   */
+  _setVisitOnModel(modelPromise, visitId) {
+    let store = get(this, 'store');
+    return modelPromise.then((model) => {
+      return store.find('visit', visitId).then((visit) => {
+        model.set('visit', visit);
+        model.set('returnToVisit', visitId);
         model.set('selectPatient', false);
         return model;
       });

--- a/app/patients/edit/controller.js
+++ b/app/patients/edit/controller.js
@@ -540,16 +540,16 @@ export default AbstractEditController.extend(BloodTypes, DiagnosisActions, Retur
   },
 
   _addChildObject(route, afterTransition) {
-    this.transitionToRoute(route, 'new').then(function(newRoute) {
-      newRoute.currentModel.setProperties({
-        patient: this.get('model'),
-        returnToPatient: this.get('model.id'),
-        selectPatient: false
-      });
+    let options = {
+      queryParams: {
+        forPatientId: this.get('model.id')
+      }
+    };
+    this.transitionToRoute(route, 'new', options).then((newRoute) => {
       if (afterTransition) {
         afterTransition(newRoute);
       }
-    }.bind(this));
+    });
   },
 
   _showEditSocial(editAttributes, modelName, route) {

--- a/app/patients/operative-plan/route.js
+++ b/app/patients/operative-plan/route.js
@@ -1,4 +1,5 @@
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import Ember from 'ember';
 import moment from 'moment';
 import { translationMacro as t } from 'ember-i18n';
@@ -8,7 +9,7 @@ const {
   inject
 } = Ember;
 
-export default AbstractEditRoute.extend({
+export default AbstractEditRoute.extend(AddToPatientRoute, {
   editTitle: t('operativePlan.titles.editTitle'),
   modelName: 'operative-plan',
   newTitle: t('operativePlan.titles.newTitle'),

--- a/app/procedures/edit/route.js
+++ b/app/procedures/edit/route.js
@@ -1,9 +1,10 @@
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatient from 'hospitalrun/mixins/add-to-patient-route';
 import ChargeRoute from 'hospitalrun/mixins/charge-route';
 import Ember from 'ember';
 import { translationMacro as t } from 'ember-i18n';
 
-export default AbstractEditRoute.extend(ChargeRoute, {
+export default AbstractEditRoute.extend(AddToPatient, ChargeRoute, {
   editTitle: t('procedures.titles.edit'),
   modelName: 'procedure',
   newTitle: t('procedures.titles.new'),

--- a/app/reports/edit/route.js
+++ b/app/reports/edit/route.js
@@ -1,8 +1,9 @@
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
+import AddToPatientRoute from 'hospitalrun/mixins/add-to-patient-route';
 import Ember from 'ember';
 import { translationMacro as t } from 'ember-i18n';
 
-export default AbstractEditRoute.extend({
+export default AbstractEditRoute.extend(AddToPatientRoute, {
   modelName: 'report',
   customForms: Ember.inject.service(),
 
@@ -13,17 +14,6 @@ export default AbstractEditRoute.extend({
     };
     let customForms = this.get('customForms');
     return customForms.setDefaultCustomForms(['opdReport', 'dischargeReport'], newReportData);
-  },
-
-  afterModel(model) {
-    if (model.get('isNew')) {
-      let visit = this.modelFor('visits.edit');
-      if (!visit) {
-        return this.transitionTo('patients');
-      }
-      model.set('visit', visit);
-    }
-    model.setProperties({ returnToVisit: model.get('visit.id') });
   },
 
   getScreenTitle(model) {

--- a/app/reports/edit/route.js
+++ b/app/reports/edit/route.js
@@ -22,6 +22,12 @@ export default AbstractEditRoute.extend(AddToPatientRoute, {
     return t(`reports.${type}.titles.${state}`);
   },
 
+  afterModel(model) {
+    if (!model.get('visit')) {
+      return this.transitionTo('patients');
+    }
+  },
+
   setupController(controller, model) {
     this._super(controller, model);
   }

--- a/app/visits/edit/controller.js
+++ b/app/visits/edit/controller.js
@@ -170,18 +170,21 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     return visitTypes;
   }.property('visitTypes', 'model.outPatient'),
 
-  _addChildObject(route, afterTransition) {
-    this.transitionToRoute(route, 'new').then(function(newRoute) {
-      newRoute.currentModel.setProperties({
-        patient: this.get('model.patient'),
-        visit: this.get('model'),
-        selectPatient: false,
-        returnToVisit: this.get('model.id')
-      });
+  _addChildObject(route, queryParamType, afterTransition) {
+    let queryParams = {};
+    if (queryParamType) {
+      if (queryParamType == 'patient') {
+        queryParams.forPatientId = this.get('model.patient.id');
+      } else if (queryParamType == 'visit') {
+        queryParams.forVisitId = this.get('model.id');
+      }
+    }
+    let options = { queryParams };
+    this.transitionToRoute(route, 'new', options).then((newRoute) => {
       if (afterTransition) {
         afterTransition(newRoute);
       }
-    }.bind(this));
+    });
   },
 
   _finishAfterUpdate() {
@@ -398,7 +401,7 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     editOperativePlan(operativePlan) {
       let model = operativePlan;
       if (isEmpty(model)) {
-        this._addChildObject('patients.operative-plan', (route) =>{
+        this._addChildObject('patients.operative-plan', 'patient', (route) =>{
           route.controller.getPatientDiagnoses(this.get('model.patient'), route.currentModel);
         });
       } else {
@@ -445,7 +448,7 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
         this.displayAlert(updateTitle, updateMesage);
         return false;
       }
-      this._addChildObject('reports.edit');
+      this._addChildObject('reports.edit', 'visit');
     },
 
     editReport() {
@@ -453,23 +456,23 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     },
 
     newAppointment() {
-      this._addChildObject('appointments.edit');
+      this._addChildObject('appointments.edit', 'patient');
     },
 
     newImaging() {
-      this._addChildObject('imaging.edit');
+      this._addChildObject('imaging.edit', 'patient');
     },
 
     newLab() {
-      this._addChildObject('labs.edit');
+      this._addChildObject('labs.edit', 'patient');
     },
 
     newMedication() {
-      this._addChildObject('medication.edit');
+      this._addChildObject('medication.edit', 'patient');
     },
 
     showAddProcedure() {
-      this._addChildObject('procedures.edit');
+      this._addChildObject('procedures.edit', 'patient');
     },
 
     showDeleteImaging(imaging) {

--- a/app/visits/edit/controller.js
+++ b/app/visits/edit/controller.js
@@ -170,16 +170,12 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     return visitTypes;
   }.property('visitTypes', 'model.outPatient'),
 
-  _addChildObject(route, queryParamType, afterTransition) {
-    let queryParams = {};
-    if (queryParamType) {
-      if (queryParamType == 'patient') {
-        queryParams.forPatientId = this.get('model.patient.id');
-      } else if (queryParamType == 'visit') {
-        queryParams.forVisitId = this.get('model.id');
+  _addChildObject(route, afterTransition) {
+    let options = {
+      queryParams: {
+        forVisitId: this.get('model.id')
       }
-    }
-    let options = { queryParams };
+    };
     this.transitionToRoute(route, 'new', options).then((newRoute) => {
       if (afterTransition) {
         afterTransition(newRoute);
@@ -401,7 +397,7 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     editOperativePlan(operativePlan) {
       let model = operativePlan;
       if (isEmpty(model)) {
-        this._addChildObject('patients.operative-plan', 'patient', (route) =>{
+        this._addChildObject('patients.operative-plan', (route) =>{
           route.controller.getPatientDiagnoses(this.get('model.patient'), route.currentModel);
         });
       } else {
@@ -448,7 +444,7 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
         this.displayAlert(updateTitle, updateMesage);
         return false;
       }
-      this._addChildObject('reports.edit', 'visit');
+      this._addChildObject('reports.edit');
     },
 
     editReport() {
@@ -456,23 +452,23 @@ export default AbstractEditController.extend(AddNewPatient, ChargeActions, Diagn
     },
 
     newAppointment() {
-      this._addChildObject('appointments.edit', 'patient');
+      this._addChildObject('appointments.edit');
     },
 
     newImaging() {
-      this._addChildObject('imaging.edit', 'patient');
+      this._addChildObject('imaging.edit');
     },
 
     newLab() {
-      this._addChildObject('labs.edit', 'patient');
+      this._addChildObject('labs.edit');
     },
 
     newMedication() {
-      this._addChildObject('medication.edit', 'patient');
+      this._addChildObject('medication.edit');
     },
 
     showAddProcedure() {
-      this._addChildObject('procedures.edit', 'patient');
+      this._addChildObject('procedures.edit');
     },
 
     showDeleteImaging(imaging) {

--- a/tests/acceptance/operative-test.js
+++ b/tests/acceptance/operative-test.js
@@ -56,7 +56,7 @@ test('Plan and report creation', function(assert) {
       waitToAppear('span.secondary-diagnosis:contains(Tennis Elbow)');
     });
     andThen(() =>{
-      assert.equal(currentURL(), '/patients/operative-plan/new', 'New operative plan URL is correct');
+      assert.equal(currentURL(), '/patients/operative-plan/new?forPatientId=C87BFCB2-F772-7A7B-8FC7-AD00C018C32A', 'New operative plan URL is correct');
       assert.equal(find('.patient-name .ps-info-data').text(), 'Joe Bagadonuts', 'Joe Bagadonuts patient header displays');
       assert.equal(find('.view-current-title').text(), 'New Operative Plan', 'New operative plan title is correct');
       assert.equal(find('span.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears as read only');

--- a/tests/acceptance/visit-test.js
+++ b/tests/acceptance/visit-test.js
@@ -68,7 +68,7 @@ test('Edit visit', function(assert) {
       click('button:contains(New Medication)');
     });
     andThen(function() {
-      assert.equal(currentURL(), '/medication/edit/new', 'New medication url is correct');
+      assert.equal(currentURL(), '/medication/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New medication url is correct');
       assert.equal(find('.patient-name .ps-info-data').text(), 'Joe Bagadonuts', 'New medication prepopulates with patient');
       click('button:contains(Cancel)');
     });
@@ -76,7 +76,7 @@ test('Edit visit', function(assert) {
       click('button:contains(New Lab)');
     });
     andThen(function() {
-      assert.equal(currentURL(), '/labs/edit/new', 'New lab url is correct');
+      assert.equal(currentURL(), '/labs/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New lab url is correct');
       assert.equal(find('.patient-name .ps-info-data').text(), 'Joe Bagadonuts', 'New lab prepopulates with patient');
       click('button:contains(Cancel)');
     });
@@ -84,7 +84,7 @@ test('Edit visit', function(assert) {
       click('button:contains(New Imaging)');
     });
     andThen(function() {
-      assert.equal(currentURL(), '/imaging/edit/new', 'New imaging url is correct');
+      assert.equal(currentURL(), '/imaging/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New imaging url is correct');
       assert.equal(find('.patient-name .ps-info-data').text(), 'Joe Bagadonuts', 'New imaging prepopulates with patient');
       click('button:contains(Cancel)');
     });


### PR DESCRIPTION
This PR fixes issues of back button, refresh, and other forms navigation to `/new` routes, from `visit` and `patient` routes.

Model IDs are now appended as query parameters to the URL to facilitate smooth navigation.